### PR TITLE
Add binance topic and datagen connector setup

### DIFF
--- a/files/flink/createBinanceVectorTable.sql
+++ b/files/flink/createBinanceVectorTable.sql
@@ -1,10 +1,11 @@
 CREATE TABLE binance_vector (
     coin_id INT,
     coin_name STRING,
-    price_usd DECIMAL(10, 2),
-    market_cap_usd DECIMAL(15, 2),
-    volume_24h_usd DECIMAL(15, 2),
-    circulating_supply DECIMAL(20, 2),
-    change_24h_percent DECIMAL(5, 2),
-    vector ARRAY<DOUBLE>
+    price_usd DOUBLE,
+    market_cap_usd DOUBLE,
+    volume_24h_usd DOUBLE,
+    circulating_supply DOUBLE,
+    change_24h_percent DOUBLE,
+    content STRING,
+    vector ARRAY<FLOAT>
 );

--- a/files/flink/queryBinanceContent.sql
+++ b/files/flink/queryBinanceContent.sql
@@ -2,10 +2,10 @@ SELECT *,
 INITCAP(
 	concat_ws(' ', 
 		coin_name, 
-		price_usd, 
-		market_cap_usd, 
-		volume_24h_usd, 
-		circulating_supply, 
-		change_24h_percent)
+		', price: ' || cast(price_usd as string),
+		', market cap: ' || cast(market_cap_usd as string),
+		', volume 24h: ' || cast(volume_24h_usd as string),
+		', circulating supply: ' || cast(circulating_supply as string),
+		', change 24h: ' || cast(change_24h_percent as string))
 ) as content 
 FROM `binance`;


### PR DESCRIPTION
Update SQL scripts to match the schema in `binanceSchema.json`.

* **`files/flink/createBinanceVectorTable.sql`**
  - Change data types of `price_usd`, `market_cap_usd`, `volume_24h_usd`, `circulating_supply`, and `change_24h_percent` to `DOUBLE`.
  - Add `content` field of type `STRING`.
  - Change data type of `vector` to `ARRAY<FLOAT>`.

* **`files/flink/queryBinanceContent.sql`**
  - Update `concat_ws` function to include labels and cast values to `STRING`.
  - Add `content` field to the `SELECT` statement.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jackgavardari/Confluent-Kafka-Vector?shareId=9f5ddc61-3dcd-4834-8d99-cd5156fd4430).