### PR TITLE
Add ML_PREDICT function to Flink SQL

### DIFF
--- a/files/flink/queryBinanceContent.sql
+++ b/files/flink/queryBinanceContent.sql
@@ -8,5 +8,6 @@ INITCAP(
 		', circulating supply: ' || cast(circulating_supply as string),
 		', change 24h: ' || cast(change_24h_percent as string))
 ) as content,
+ml_predict('vector_encoding', content) as vector,
 ml_evaluate('accuracy', actual_label, predicted_label) as evaluation_result
 FROM `binance`;

--- a/files/flink/queryProductContent.sql
+++ b/files/flink/queryProductContent.sql
@@ -10,5 +10,6 @@ INITCAP(
 		baseColor, 
 		articleType)
 ) as content,
+ml_predict('vector_encoding', content) as vector,
 ml_evaluate('accuracy', actual_label, predicted_label) as evaluation_result
 from `product-updates`;


### PR DESCRIPTION
Add `ml_predict` function to generate vector encoding for `binance` and `product-updates` topics in Flink SQL.

* **queryBinanceContent.sql**
  - Add `ml_predict` function to generate vector encoding for the `binance` topic.
  - Update the `SELECT` statement to include the `vector` field.

* **queryProductContent.sql**
  - Add `ml_predict` function to generate vector encoding for the `product-updates` topic.
  - Update the `SELECT` statement to include the `vector` field.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jackgavardari/Confluent-Kafka-Vector?shareId=e585f888-604b-42d9-98ec-030be9f8b7e9).